### PR TITLE
[DPE-3232] OCI-factory integration

### DIFF
--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -6,7 +6,7 @@ base: ubuntu@22.04  # the base environment for this ROCK
 version: '3.8.2'  # just for humans. Semantic versioning is recommended
 summary: Apache ZooKeeper OCI Image  # 79 char long summary
 description: |
-  Current Apache ZooKeeper Docker Image from Canonical, based
+  Apache ZooKeeper Image from Canonical, based
   on [Ubuntu](https://ubuntu.com/). Receives security updates and tracks the
   newest combination of Apache ZooKeeper and Ubuntu. This
   repository is free to use and exempted from per-user rate limits.
@@ -45,10 +45,14 @@ parts:
       "https://github.com/canonical/central-uploader/releases/download\
       /zookeeper-${CRAFT_PROJECT_VERSION}-ubuntu0\
       /zookeeper-${CRAFT_PROJECT_VERSION}-ubuntu0-20231121152605.tgz"
-    stage-packages:
+    overlay-packages:
       - openjdk-8-jre-headless
-    build-environment:
-      - JAVA_HOME: /usr/lib/jvm/java-8-openjdk-amd64/
+    overlay-script: |
+      # Java linking
+      rm usr/bin/java
+      rm -vf usr/lib/jvm/java-8-openjdk-amd64/lib/security/cacerts
+      ln -s /usr/lib/jvm/java-8-openjdk-amd64/bin/java usr/bin/java
+
     override-build: |
       # Base directory skeleton
       mkdir -p $CRAFT_PART_INSTALL/var/lib/zookeeper/
@@ -70,14 +74,6 @@ parts:
         $CRAFT_PART_INSTALL/etc/zookeeper/zoo.cfg
       echo "dataLogDir=/var/lib/zookeeper/data-log" >> \
         $CRAFT_PART_INSTALL/etc/zookeeper/zoo.cfg
-
-      # Java linking
-      ln -s /usr/lib/jvm/java-8-openjdk-amd64/bin/java \
-        $CRAFT_PART_INSTALL/usr/bin/java
-
-    override-prime: |
-      craftctl default
-      rm -vf usr/lib/jvm/java-8-openjdk-amd64/lib/security/cacerts
 
   non-root-user:
     plugin: nil

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -108,8 +108,23 @@ parts:
 
   deb-security-manifest:
     plugin: nil
-    after: [ non-root-user ]
+    after: [non-root-user]
     override-prime: |
       set -x
       mkdir -p $CRAFT_PRIME/usr/share/rocks/
-      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query
+
+      FIELDS=(
+        '${db:Status-Abbrev}'
+        '${binary:Package}'
+        '${Version}'
+        '${source:Package}'
+        '${Source:Version}\n'
+      )
+
+      # yamllint disable-line rule:line-length
+      (
+        IFS="," && \
+        echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
+        dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ \
+        -f "${FIELDS[*]}" -W
+      ) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -48,10 +48,8 @@ parts:
     overlay-packages:
       - openjdk-8-jre-headless
     overlay-script: |
-      # Java linking
-      rm usr/bin/java
+      # Removing cacerts
       rm -vf usr/lib/jvm/java-8-openjdk-amd64/lib/security/cacerts
-      ln -s /usr/lib/jvm/java-8-openjdk-amd64/bin/java usr/bin/java
 
     override-build: |
       # Base directory skeleton

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -105,3 +105,11 @@ parts:
 
       find etc/zookeeper -type d -print0 | xargs -0 chmod 0775
       find etc/zookeeper -type f -print0 | xargs -0 chmod 0664
+
+  deb-security-manifest:
+    plugin: nil
+    after: [ non-root-user ]
+    override-prime: |
+      set -x
+      mkdir -p $CRAFT_PRIME/usr/share/rocks/
+      (echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f '${db:Status-Abbrev},${binary:Package},${Version},${source:Package},${Source:Version}\n' -W) > $CRAFT_PRIME/usr/share/rocks/dpkg.query

--- a/rockcraft.yaml
+++ b/rockcraft.yaml
@@ -121,10 +121,8 @@ parts:
         '${Source:Version}\n'
       )
 
-      # yamllint disable-line rule:line-length
       (
         IFS="," && \
         echo "# os-release" && cat /etc/os-release && echo "# dpkg-query" && \
-        dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ \
-        -f "${FIELDS[*]}" -W
+        dpkg-query --admindir=$CRAFT_PRIME/var/lib/dpkg/ -f "${FIELDS[*]}" -W
       ) > $CRAFT_PRIME/usr/share/rocks/dpkg.query


### PR DESCRIPTION
Adding Manifest files to comply with Security Requirements for Rocks images published by OCI Factory. 

For more information, refer to [here](https://github.com/canonical/oci-factory/blob/main/IMAGE_MAINTAINER_AGREEMENT.md#enable-security-monitoring).